### PR TITLE
Implemented encrypted NextDNS connectivity verification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.6.1'
     implementation 'androidx.core:core:1.10.1'
     implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'io.sentry:sentry-android:6.19.1'
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))

--- a/app/src/main/java/com/doubleangels/nextdnsmanagement/checktest/TestApi.java
+++ b/app/src/main/java/com/doubleangels/nextdnsmanagement/checktest/TestApi.java
@@ -1,0 +1,16 @@
+package com.doubleangels.nextdnsmanagement.checktest;
+
+import com.google.gson.JsonObject;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
+
+public interface TestApi {
+    @Headers({
+        "Accept: application/json",
+        "Cache-Control: no-cache"
+    })
+    @GET("/")
+    Call<JsonObject> getResponse();
+}

--- a/app/src/main/java/com/doubleangels/nextdnsmanagement/checktest/TestClient.java
+++ b/app/src/main/java/com/doubleangels/nextdnsmanagement/checktest/TestClient.java
@@ -1,0 +1,21 @@
+package com.doubleangels.nextdnsmanagement.checktest;
+
+import android.content.Context;
+
+import com.doubleangels.nextdnsmanagement.R;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class TestClient {
+    private static Retrofit retrofit = null;
+    public static Retrofit getBaseClient(Context c) {
+        if (retrofit == null) {
+            retrofit = new Retrofit.Builder()
+                    .baseUrl(c.getString(R.string.test_url))
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build();
+        }
+        return retrofit;
+    }
+}

--- a/app/src/main/res/drawable/failure_orange.xml
+++ b/app/src/main/res/drawable/failure_orange.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"
+      android:fillColor="@color/orange"/>
+</vector>

--- a/app/src/main/res/layout/activity_help.xml
+++ b/app/src/main/res/layout/activity_help.xml
@@ -41,22 +41,22 @@
         android:layout_width="75dp"
         android:layout_height="75dp"
         android:layout_marginTop="30dp"
+        android:contentDescription="@string/generic_content_description"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/yellowDemoTextView"
-        app:srcCompat="@drawable/failure_red"
-        android:contentDescription="@string/generic_content_description"/>
+        app:layout_constraintTop_toBottomOf="@+id/orangeDemoTextView"
+        app:srcCompat="@drawable/failure_red" />
 
     <ImageView
         android:id="@+id/greenDemo"
         android:layout_width="75dp"
         android:layout_height="75dp"
-        android:layout_marginTop="28dp"
+        android:layout_marginTop="30dp"
+        android:contentDescription="@string/generic_content_description"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar"
-        app:srcCompat="@drawable/success_green"
-        android:contentDescription="@string/generic_content_description"/>
+        app:srcCompat="@drawable/success_green" />
 
     <TextView
         android:id="@+id/greenDemoTextView"
@@ -99,14 +99,33 @@
         android:layout_width="250dp"
         android:layout_height="40dp"
         android:layout_marginTop="14dp"
-        android:layout_marginBottom="64dp"
         android:gravity="center"
         android:text="@string/help_red"
         android:textColor="?android:attr/textColorPrimary"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/redDemo"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintTop_toBottomOf="@+id/redDemo" />
+
+    <ImageView
+        android:id="@+id/orangeDemo"
+        android:layout_width="75dp"
+        android:layout_height="75dp"
+        android:layout_marginTop="30dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/yellowDemoTextView"
+        app:srcCompat="@drawable/failure_orange" />
+
+    <TextView
+        android:id="@+id/orangeDemoTextView"
+        android:layout_width="250dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="14dp"
+        android:gravity="center"
+        android:text="@string/help_orange"
+        android:textColor="?android:attr/textColorPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/orangeDemo" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-round/strings.xml
+++ b/app/src/main/res/values-round/strings.xml
@@ -15,6 +15,7 @@
     <string name="update_channel_description">This is the main update channel for NextDNS Manager.</string>
     <string name="help_green">Secure DNS is being used AND device is connected to NextDNS.</string>
     <string name="help_yellow">Secure DNS is being used but device is NOT connected to NextDNS.</string>
+    <string name="help_orange">Secure DNS is NOT being used AND device is connected to NextDNS.</string>
     <string name="help_red">Secure DNS is NOT being used.</string>
     <string name="generic_content_description">This is a generic content description.</string>
     <string name="disclaimer">This app is NOT an official NextDNS app. This app and its developer are NOT in any way affiliated or related to NextDNS.</string>
@@ -53,4 +54,7 @@
     <string name="author_website_url">https://doubleangels.com</string>
     <string name="privacy">Privacy Policy</string>
     <string name="privacy_policy_url">https://doubleangels.com/privacy/nextdns.html</string>
+    <string name="nextdns_status">status</string>
+    <string name="nextdns_protocol">protocol</string>
+    <string name="using_nextdns_status">OK</string>
 </resources>

--- a/app/src/main/res/values/protocols.xml
+++ b/app/src/main/res/values/protocols.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="secure_protocols">
+        <item>DOH</item>
+        <item>DOT</item>
+        <item>DOQ</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="update_channel_description">This is the main update channel for NextDNS Manager.</string>
     <string name="help_green">Secure DNS is being used AND device is connected to NextDNS.</string>
     <string name="help_yellow">Secure DNS is being used but device is NOT connected to NextDNS.</string>
+    <string name="help_orange">Secure DNS is NOT being used AND device is connected to NextDNS.</string>
     <string name="help_red">Secure DNS is NOT being used.</string>
     <string name="generic_content_description">This is a generic content description.</string>
     <string name="disclaimer">This app is NOT an official NextDNS app. This app and its developer are NOT in any way affiliated or related to NextDNS.</string>
@@ -53,4 +54,7 @@
     <string name="author_website_url">https://doubleangels.com</string>
     <string name="privacy">Privacy Policy</string>
     <string name="privacy_policy_url">https://doubleangels.com/privacy/nextdns.html</string>
+    <string name="nextdns_status">status</string>
+    <string name="nextdns_protocol">protocol</string>
+    <string name="using_nextdns_status">OK</string>
 </resources>


### PR DESCRIPTION
## Changes

- Improves the Visual Indicator by testing whether dns requests are routed through NextDNS

  - Visual Indicator accuracy is therefore improved given the following scenario:

    - Private Dns -> off

    - dns inherited from WiFi/VPN/Cellular sets NextDNS as the dns server

- Adds orange failure indicator to signal (the `help` menu was updated to indicate this change):

  - Dns is NOT secure, yet NextDNS is being used (e.g. over udp, tcp, etc.)

## Dependencies Added

- Retrofit2 v2.9.0

## Tested On

- Verified in Android Studio simulator (pixel device on Android 13)

- Verified on LG V60 AT&T Android 13 (software version V600AM40b)

## Testing Done (Non-Exhaustive List)

- Verified that the original, Private Dns checking, method is still functional

- Verified that the new, inherited dns checking, method works in the following scenarios (Private DNS -> off):

  - WiFi delivers nextdns securely over https AND success green checkmark

  - VPN delivers nextdns insecurely over udp AND failure orange triangle

  - Cellular does NOT deliver nextdns AND failure red triangle